### PR TITLE
Ensure breakers open on Master Stop

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -809,6 +809,12 @@ function updatePhysics(){
     state.Gate_Pos_Var = Gate_Setpoint;
   }
 
+  // During a Master Stop, automatically open breakers once gates fall low
+  if (state.MasterStopMask && state.Gate_Pos_Var <= FREQ_GATE_THRESH_PCT) {
+    if (state['52G_Brk_Var']) handleAction('52G_OPEN');
+    if (state['41_Brk_Var']) handleAction('41_OPEN');
+  }
+
   /// Frequency (single-owner slew): on-grid=60; off-grid rises follow gate; falls decay at fixed rate
   {
     const onGrid = !!state['52G_Brk_Var'];


### PR DESCRIPTION
## Summary
- Open generator (52G) and field (41) breakers automatically when gates drop below 20% during a Master Stop

## Testing
- `node --check Script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7c95ec4a483308b9bfeed943e7868