### PR TITLE
Avoid 86G trip on normal shutdown

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -876,6 +876,8 @@ function updatePhysics(){
       state.Master_Started = false;
       stopRamp.active      = false;
       updatePhysics._wasRunning = false;
+      // Mark generator offline so protections don't evaluate after a normal stop
+      state.GeneratorOnline = false;
       logDebug('Unit Stopped');
     }
   }


### PR DESCRIPTION
## Summary
- mark generator offline when a normal stop completes so trips aren't evaluated

## Testing
- `node --check Script.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a7cd5e079c83309535ba4a5c6b44ff