### PR TITLE
Color-coded alarm and trip messages in debug log

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -11125,7 +11125,7 @@
       background:#0b0f14; color:#e5e7eb;
       border:1px solid #6b7280; border-radius:6px;
       padding:8px; font:12px/1.35 Consolas,"Courier New",monospace;
-      scrollbar-width:none;
+      scrollbar-width:none; white-space:pre-wrap;
     }
     #Debug_Log::-webkit-scrollbar{ width:0; height:0; }
     #Debug_Slider{
@@ -11154,7 +11154,7 @@
 
     var dock = document.createElement('div');
     dock.id = 'DebugDock';
-    dock.innerHTML = '<textarea id="Debug_Log" spellcheck="false"></textarea>' +
+    dock.innerHTML = '<div id="Debug_Log" spellcheck="false"></div>' +
                      '<input id="Debug_Slider" type="range" min="0" max="100" value="0">';
     var _wrap = document.getElementById("sim-wrap");
     (_wrap ? _wrap : document.body).appendChild(dock);

--- a/Script.js
+++ b/Script.js
@@ -73,17 +73,30 @@ function __setDebugWindow(win){ __DEBUG_WIN = win; }
 /* ///////////// Section 2.B logDebug ///////////// */
 function logDebug(message){
   try {
-    try { console.log(message); } catch(_) {}
+    const msg = String(message);
+    try { console.log(msg); } catch(_) {}
     const el = document.getElementById('Debug_Log');
     if (el){
-      if (typeof el.value === 'string'){
-        el.value += (el.value ? "\n" : "") + String(message);
-      } else {
-        el.textContent = (el.textContent ? el.textContent + "\n" : "") + String(message);
+      const line = document.createElement('div');
+      line.textContent = msg;
+      const lower = msg.toLowerCase();
+      if (lower.includes('alarm')){
+        if (lower.includes('active') || lower.includes('true')){
+          line.style.color = 'red';
+        } else if (lower.includes('false') || lower.includes('cleared')){
+          line.style.color = 'limegreen';
+        }
+      } else if (lower.includes('trip')){
+        if (lower.includes('cleared') || lower.includes('reset') || lower.includes('false')){
+          line.style.color = 'limegreen';
+        } else {
+          line.style.color = 'red';
+        }
       }
+      el.appendChild(line);
     }
     if(__DEBUG_WIN && !__DEBUG_WIN.closed){
-      __DEBUG_WIN.postMessage(String(message), '*');
+      __DEBUG_WIN.postMessage(msg, '*');
     }
   } catch(_) {}
 }


### PR DESCRIPTION
## Summary
- Colorize debug log entries: alarms and trips show red when active and green when cleared
- Switch debug log to div container supporting styled lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7da076ed883309bc7c2565b863a05