### PR TITLE
fix: improve debug log readability

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -11122,7 +11122,7 @@
     #Debug_Log{
       grid-column:1/2; grid-row:1;
       width:95%; height:98%; resize:none; overflow:auto;
-      background:#0b0f14; color:#e5e7eb;
+      background:#ffffff; color:#000000;
       border:1px solid #6b7280; border-radius:6px;
       padding:8px; font:12px/1.35 Consolas,"Courier New",monospace;
       scrollbar-width:none; white-space:pre-wrap;

--- a/Script.js
+++ b/Script.js
@@ -82,7 +82,7 @@ function logDebug(message){
       const lower = msg.toLowerCase();
       if (lower.includes('alarm')){
         if (lower.includes('active') || lower.includes('true')){
-          line.style.color = 'red';
+          line.style.color = '#ffbf00';
         } else if (lower.includes('false') || lower.includes('cleared')){
           line.style.color = 'limegreen';
         }


### PR DESCRIPTION
## Summary
- switch debug log background to white with black text
- highlight active alarms in amber instead of red

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7db82ac3883309f750766ebf5fed4