### PR TITLE
Refine alarm and trip messaging with darker colors

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -11124,7 +11124,7 @@
       width:95%; height:98%; resize:none; overflow:auto;
       background:#f5f5f5; color:#000000;
       border:1px solid #6b7280; border-radius:6px;
-      padding:8px; font:bold 16px/1.35 Consolas,"Courier New",monospace;
+      padding:8px; font:bold 18px/1.35 Consolas,"Courier New",monospace;
       scrollbar-width:none; white-space:pre-wrap;
     }
     #Debug_Log::-webkit-scrollbar{ width:0; height:0; }


### PR DESCRIPTION
## Summary
- use darker amber/green for debug log entries and enlarge debug font
- provide descriptive alarm and trip messages including overspeed detection
- drop master stop mask debug chatter

## Testing
- `node --check Script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7ea5107588330b706d3c0900582be