### PR TITLE
feat: auto-scroll debug log

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -96,6 +96,9 @@ function logDebug(message){
       }
       if (color) line.style.color = color;
       el.appendChild(line);
+      // Always scroll to the bottom so newest messages are visible
+      // even when the log overflows the viewable area
+      try { el.scrollTop = el.scrollHeight; } catch (_) {}
     }
     if(__DEBUG_WIN && !__DEBUG_WIN.closed){
       __DEBUG_WIN.postMessage(msg, '*');


### PR DESCRIPTION
## Summary
- always scroll debug log to the bottom after new messages

## Testing
- `node --check Script.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a81c94eaf083308857988cc11ca359