### PR TITLE
Improve amber glow and overspeed warning

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -87,6 +87,8 @@ function logDebug(message){
         } else {
           color = 'red';
         }
+      } else if (lower.includes('overspeed')) {
+        color = 'red';
       } else if (lower.includes('alarm') || lower.includes('active') || lower.includes('inactive') || lower.includes('abnormal') || lower.includes('normal')){
         if (lower.includes('inactive') || lower.includes('normal') || lower.includes('false') || lower.includes('cleared')){
           color = '#006400';

--- a/index.html
+++ b/index.html
@@ -41,9 +41,10 @@
       <stop offset="100%" stop-color="#000" stop-opacity="0.08"/>
     </radialGradient>
 
-<radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
-  <stop offset="0%"   stop-color="#bf7f00" stop-opacity="1"/>
-  <stop offset="100%" stop-color="#bf7f00" stop-opacity="0"/>
+<radialGradient id="glowAmber" cx="50%" cy="50%" r="60%">
+  <stop offset="0%"   stop-color="#fff5e0" stop-opacity="1"/>
+  <stop offset="40%"  stop-color="#ffa500" stop-opacity="1"/>
+  <stop offset="100%" stop-color="#ffa500" stop-opacity="0"/>
 </radialGradient>
 
   </defs>
@@ -10948,7 +10949,7 @@
            cy="20.981564"
            rx="5.0661173"
            ry="5.1065636" /></g></g></g></svg></div>
-<footer>Contact me <a href="mailto:GenSyncScope@gmail.com">GenSyncScope@gmail.com</a></footer>
+<footer>Suggestions? Contact me: <a href="mailto:GenSyncScope@gmail.com">GenSyncScope@gmail.com</a></footer>
 <script src="script.js"></script>
 
 <script>


### PR DESCRIPTION
## Summary
- Highlight 'Overspeed Detected' debug entries in red
- Make the amber glow indicator brighter with an orange illumination
- Update contact footer copy for suggestions

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a81f9f6f2483308e92588e8408b546