### PR TITLE
Use pointer events for knob dragging

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -165,12 +165,13 @@ switches.forEach(cfg => {
     knob.setAttribute('transform', `rotate(${ang} ${cx} ${cy})`);
   }
 
-  hitU.addEventListener('mousedown', (e)=>{
+  hitU.addEventListener('pointerdown', (e)=>{
     e.preventDefault();
+    e.target.setPointerCapture(e.pointerId);
     knobStates[cfg.knobId].isDragging = true;
     knobStates[cfg.knobId].startX = e.clientX;
-    document.addEventListener('mousemove', onMoveU);
-    document.addEventListener('mouseup', onUp);
+    document.addEventListener('pointermove', onMoveU);
+    document.addEventListener('pointerup', onUp);
   });
   function onMoveU(e){
     if(!knobStates[cfg.knobId].isDragging) return;
@@ -179,12 +180,13 @@ switches.forEach(cfg => {
     setAngle(cfg.knobId, ang);
   }
 
-  hitL.addEventListener('mousedown', (e)=>{
+  hitL.addEventListener('pointerdown', (e)=>{
     e.preventDefault();
+    e.target.setPointerCapture(e.pointerId);
     knobStates[cfg.knobId].isDragging = true;
     knobStates[cfg.knobId].startX = e.clientX;
-    document.addEventListener('mousemove', onMoveL);
-    document.addEventListener('mouseup', onUp);
+    document.addEventListener('pointermove', onMoveL);
+    document.addEventListener('pointerup', onUp);
   });
   function onMoveL(e){
     if(!knobStates[cfg.knobId].isDragging) return;
@@ -193,7 +195,7 @@ switches.forEach(cfg => {
     setAngle(cfg.knobId, ang);
   }
 
-  function onUp(){
+  function onUp(e){
     if(!knobStates[cfg.knobId].isDragging) return;
     knobStates[cfg.knobId].isDragging = false;
 
@@ -205,9 +207,10 @@ switches.forEach(cfg => {
       setAngle(cfg.knobId, returnAngle);
     }
 
-    document.removeEventListener('mousemove', onMoveU);
-    document.removeEventListener('mousemove', onMoveL);
-    document.removeEventListener('mouseup', onUp);
+    document.removeEventListener('pointermove', onMoveU);
+    document.removeEventListener('pointermove', onMoveL);
+    document.removeEventListener('pointerup', onUp);
+    try { e.target.releasePointerCapture(e.pointerId); } catch(_){ }
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   body { margin: 0; background: #cfd4da; }
   #panel-bg { position: fixed; inset: 0; z-index: -1; }
 #sim-wrap { position: relative; display: inline-block; }
+[id^="Hit_"] { touch-action: none; }
 </style>
 <body>
 <svg id="panel-bg" width="100%" height="100%" preserveAspectRatio="none" role="presentation" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Switch all knob drag handlers to pointer events with pointer capture
- Prevent touch scrolling on switch hit zones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82112d09c8330859abe2dedc3c492