### PR TITLE
Prevent kV drop when switching AVR to manual

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -306,10 +306,6 @@ const FREQ_DECEL_SLOW_HZ_S = FREQ_DECEL_HZ_S / .25; // half-rate below threshold
 // AVR line-drop compensation (disabled if 0)
 const AVR_LDC_PU = 0.00;
 
-// Manual (AVR OFF) droop: pu kV sag per 1.0 pu stator current
-const MANUAL_DROOP_PU = 0.12;   // try 0.08–0.15
-const MANUAL_Q_GAIN   = 0.0;    // extra sag for lagging vars (0..1)
-
 // Power mapping: physical gate needed for ~0 MW when paralleled
 const NO_LOAD_GATE_PCT = 20;    // set near your sync gate (e.g., 18–20)
 const REV_PWR_LIMIT_MW = -5;  // cap reverse power (negative)
@@ -646,27 +642,15 @@ function handleAction(tag){
       }
     }
 
-    // On disabling AVR, store SP and freeze so manual droop maintains present kV
+    // On disabling AVR, store SP and freeze setpoint at present kV
     if (tag === 'AVR_OFF' && wasAVR && state) {
       state.__avrStoredSP = state.Gen_kV_SP;
       const kv = Math.max(0, +state.Gen_kV_Var || 0);
-      const Vbus = state.Bus_Voltage_kV || 13.8;
-      const Ipu = clamp((state.AMPS || 0) / (RATED.AMPS || 1), 0, 2);
-      const Qpu = clamp((state.MVAR || 0) / (RATED.MVAR_LAG_MAX || 1), -1, 1);
-      const extra = 1 + MANUAL_Q_GAIN * Math.max(0, Qpu);
-      const V_droop = Vbus * MANUAL_DROOP_PU * Ipu * extra;
-      const sp = kv + V_droop; // final SP once droop fully applied
-      const BLEND_MS = 300;
-      const now = (typeof performance !== 'undefined' && performance.now)
-        ? performance.now()
-        : Date.now();
-      state.__avrOffBlend = { kv, sp, t0: now, dur: BLEND_MS };
-      state.Gen_kV_SP = kv;   // start at present kV; ramp SP and droop separately
+      state.Gen_kV_SP  = kv;  // freeze setpoint to present kV
       state.Gen_kV_Var = kv;
       try {
-        const spStr = sp.toFixed(2);
         const kvStr = kv.toFixed(2);
-        logDebug(`AVR transition to MANUAL: SP ${spStr} kV, V ${kvStr} kV`);
+        logDebug(`AVR transition to MANUAL: V ${kvStr} kV`);
       } catch(_){}
     }
 
@@ -948,21 +932,8 @@ function updatePhysics(){
       let kvTargetSP = state.Gen_kV_SP;
       slewGenKV(kvTargetSP, KV_SLEW_AUTO);
     } else {
-      // MANUAL: droop with load (ramp-in on AVR->manual transition)
-      let droopScale = 1;
-      if (state.__avrOffBlend) {
-        const b = state.__avrOffBlend;
-        const α = clamp((performance.now() - b.t0) / b.dur, 0, 1);
-        state.Gen_kV_SP = b.kv + (b.sp - b.kv) * α;
-        droopScale = α;
-        if (α >= 1) delete state.__avrOffBlend;
-      }
-      const Ipu = clamp((state.AMPS || 0) / (RATED.AMPS || 1), 0, 2);
-      const Qpu = clamp((state.MVAR || 0) / (RATED.MVAR_LAG_MAX || 1), -1, 1);
-      const extra = 1 + MANUAL_Q_GAIN * Math.max(0, Qpu);
-      const V_droop = Vbus * MANUAL_DROOP_PU * Ipu * extra;
-      const target  = state.Gen_kV_SP - V_droop * droopScale;
-      slewGenKV(target, KV_SLEW_MANUAL);
+      // MANUAL: track setpoint without droop
+      slewGenKV(state.Gen_kV_SP, KV_SLEW_MANUAL);
     }
   } else {
     // Not paralleled: track SP if field on, else decay to 0


### PR DESCRIPTION
## Summary
- remove manual droop constants and logic
- track generator voltage setpoint directly in manual mode
- freeze setpoint at current voltage when AVR is disabled

## Testing
- `node --check Script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a84d3c00408330b14d30668a3798e6