### PR TITLE
fix: highlight power factor abnormal log in amber

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -90,7 +90,7 @@ function logDebug(message){
       } else if (lower.includes('overspeed')) {
         color = 'red';
       } else if (lower.includes('alarm') || lower.includes('active') || lower.includes('inactive') || lower.includes('abnormal') || lower.includes('normal')){
-        if (lower.includes('inactive') || lower.includes('normal') || lower.includes('false') || lower.includes('cleared')){
+        if (lower.includes('inactive') || (lower.includes('normal') && !lower.includes('abnormal')) || lower.includes('false') || lower.includes('cleared')){
           color = '#006400';
         } else {
           color = '#b8860b';


### PR DESCRIPTION
## Summary
- ensure `logDebug` treats `abnormal` messages as active alarms rather than normal
- color "Power Factor Abnormal" debug entries in amber like other active alarms

## Testing
- `node --check Script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b27a353000833080ced70f0252db57