### PR TITLE
Remove Knob 65 gate delay

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -740,28 +740,16 @@ function handleAction(tag){
 
     const a65 = angleOf('Knob_65') || 0;
 
-    if (Math.abs(a65) >= NUDGE_THRESH) {
-      const dir = Math.sign(a65);
-      if (updateGateSet._pendingDir !== dir) {
-        updateGateSet._pendingDir = dir;
-        updateGateSet._startTime = now;
+    if (a65 >= NUDGE_THRESH){
+      Gate_Setpoint = Math.min(100, Gate_Setpoint + NUDGE_RATE * dt);
+      if (updateGateSet._lastLog == null || Math.abs(Gate_Setpoint - updateGateSet._lastLog) >= 0.5){
+        updateGateSet._lastLog = Gate_Setpoint;
       }
-      if (now - (updateGateSet._startTime || 0) >= 1000) {
-        if (dir > 0) {
-          Gate_Setpoint = Math.min(100, Gate_Setpoint + NUDGE_RATE * dt);
-        } else {
-          Gate_Setpoint = Math.max(0, Gate_Setpoint - NUDGE_RATE * dt);
-        }
-        if (
-          updateGateSet._lastLog == null ||
-          Math.abs(Gate_Setpoint - updateGateSet._lastLog) >= 0.5
-        ) {
-          updateGateSet._lastLog = Gate_Setpoint;
-        }
+    } else if (a65 <= -NUDGE_THRESH){
+      Gate_Setpoint = Math.max(0, Gate_Setpoint - NUDGE_RATE * dt);
+      if (updateGateSet._lastLog == null || Math.abs(Gate_Setpoint - updateGateSet._lastLog) >= 0.5){
+        updateGateSet._lastLog = Gate_Setpoint;
       }
-    } else {
-      updateGateSet._pendingDir = 0;
-      updateGateSet._startTime = null;
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove 1-second delay logic for Knob_65 gate setpoint adjustments
- Revert gate nudge behavior to immediate response

## Testing
- `node --check Script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b28805af48833085a386b655505a22