### PR TITLE
Add immediate trip on breaker openings

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -512,6 +512,7 @@ function handleAction(tag){
         kvRamp.to   = 0;
         kvRamp.dur  = KV_RAMP_MS;
         kvRamp.t0   = performance.now();
+        if(state['52G_Brk_Var']){ logFlag('Trip_40', true); }
       }
       break;
 
@@ -560,6 +561,7 @@ function handleAction(tag){
         state['52G_Brk_Var'] = false;
         delete state.NoLoadGateCal;
         try{ logDebug('52G: OPEN'); }catch(_){}
+        handleAction('86G_TRIP');
       }
       break;
 


### PR DESCRIPTION
## Summary
- Trigger 40 loss-of-field trip when field breaker opens while generator breaker is closed
- Trip 86G lockout whenever the generator breaker opens

## Testing
- `node --check Script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b28fb4e8208330b9236d79b5c30020