### PR TITLE
Trigger trip on field breaker open

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -512,7 +512,10 @@ function handleAction(tag){
         kvRamp.to   = 0;
         kvRamp.dur  = KV_RAMP_MS;
         kvRamp.t0   = performance.now();
-        if(state['52G_Brk_Var']){ logFlag('Trip_40', true); }
+        if(state['52G_Brk_Var']){
+          logFlag('Trip_40', true);
+          try{ handleAction('86G_TRIP'); }catch(_){ }
+        }
       }
       break;
 


### PR DESCRIPTION
## Summary
- ensure opening the field breaker while generator breaker is closed triggers a full protective trip

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b292cbefe083309f9ed12c357cdbd3