### PR TITLE
Trigger 86G trip when field breaker opens

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -1648,6 +1648,7 @@ requestAnimationFrame(tick);
     PROT.t40B = t40 ? PROT.t40B + dt : 0;
     if (!S.Trip_40 && (PROT.t40A >= 0.05 || PROT.t40B >= 0.05)) {
       logFlag('Trip_40', true);
+      try { handleAction('86G_TRIP'); } catch(_) {}
     }
 
     // 27/59 — Voltage trips (0.5 s either side)


### PR DESCRIPTION
## Summary
- Trip the generator lockout (86G) whenever the field breaker (41) opens while the generator breaker is closed, ensuring a proper loss-of-field response

## Testing
- `node --check Script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b29a64c5408330a89664f601604587